### PR TITLE
Add UUID to recognized fields

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,7 @@ So far, field generation is supported for the following types and their subclass
 * ``str``, ``bool``, ``int`` and ``float``.
 * ``date``, ``datetime``, ``time`` and ``timedelta`` from the ``datetime`` package.
 * ``decimal.Decimal`` (requires specifying ``max_digits`` and ``decimal_places`` through ``extra_kwargs``).
+* ``uuid.UUID``
 * ``typing.Iterable`` (including ``typing.List``).
 * ``typing.Mapping`` (including ``typing.Dict``).
 * ``django.db.Model``

--- a/rest_framework_dataclasses/serializers.py
+++ b/rest_framework_dataclasses/serializers.py
@@ -2,6 +2,7 @@ import copy
 import dataclasses
 import datetime
 import decimal
+import uuid
 from collections import OrderedDict
 from typing import List, Type, Dict, Any, Tuple, Mapping, NoReturn
 
@@ -50,7 +51,8 @@ class DataclassSerializer(rest_framework.serializers.Serializer):
         datetime.date:      rest_framework.fields.DateField,
         datetime.datetime:  rest_framework.fields.DateTimeField,
         datetime.time:      rest_framework.fields.TimeField,
-        datetime.timedelta: rest_framework.fields.DurationField
+        datetime.timedelta: rest_framework.fields.DurationField,
+        uuid.UUID:          rest_framework.fields.UUIDField,
     }
     serializer_related_field = PrimaryKeyRelatedField
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import typing
+import uuid
 
 from dataclasses import dataclass
 
@@ -13,6 +14,7 @@ class Pet:
 
 @dataclass
 class Person:
+    id: uuid.UUID
     name: str
     email: str
     alive: bool

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -20,7 +20,10 @@ class SerializerTestCase(TestCase):
 
         serializer = PersonSerializer()
         f = serializer.get_fields()
-        self.assertEqual(len(f), 8)
+        self.assertEqual(len(f), 9)
+
+        self.assertIsInstance(f['id'], fields.UUIDField)
+        self.assertFalse(f['id'].allow_null)
 
         self.assertIsInstance(f['name'], fields.CharField)
         self.assertFalse(f['name'].allow_null)


### PR DESCRIPTION
This adds UUID to the list of automatically recognized dataclass fields, mapping it to a UUIDField in DRF.