### PR TITLE
Add Literal["values"] field support, convert to a ChoiceField

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ For example, define a dataclass as follows:
         name: str
         email: str
         alive: bool
+        gender: typing.Literal['male', 'female']
         birth_date: typing.Optional[datetime.date]
         phone: typing.List[str]
         movie_ratings: typing.Dict[str, int]
@@ -77,6 +78,7 @@ The serializer for this dataclass can now trivially be defined without having to
         name = fields.CharField()
         email = fields.CharField()
         alive = fields.BooleanField()
+        gender = fields.ChoiceField(choices=['male', 'female'])
         birth_date = fields.DateField(allow_null=True)
         phone = fields.ListField(child=fields.CharField())
         movie_ratings = fields.DictField(child=fields.IntegerField())

--- a/rest_framework_dataclasses/typing_utils.py
+++ b/rest_framework_dataclasses/typing_utils.py
@@ -11,6 +11,12 @@ experimental. Maybe for the future.
 import collections
 import typing
 
+try:
+    # Python 3.8 and later
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 
 def is_iterable_type(tp: type) -> bool:
     """
@@ -113,3 +119,19 @@ def get_optional_type(tp: type) -> type:
         raise ValueError('get_optional_type() called with non-optional type.')
 
     return next(argument_type for argument_type in tp.__args__ if argument_type is not type(None))
+
+
+def is_literal_type(tp: type) -> bool:
+    """
+    Is this type a Literal[...] expression?
+    """
+    # Stolen from typing_inspect
+    return (tp is Literal
+            or (isinstance(tp, typing._GenericAlias) and tp.__origin__ is Literal))
+
+
+def get_literal_choices(tp: type) -> tuple:
+    """
+    Return the possible values from a Literal[...] expression.
+    """
+    return tp.__args__

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         'django>=1.11',
-        'djangorestframework>=3.9'
+        'djangorestframework>=3.9',
+        'typing_extensions>=3.7.4; python_version<"3.8"'
     ]
 )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,6 +5,12 @@ import uuid
 
 from dataclasses import dataclass
 
+try:
+    # Python 3.8 and later
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 
 @dataclass
 class Pet:
@@ -18,6 +24,7 @@ class Person:
     name: str
     email: str
     alive: bool
+    gender: Literal['male', 'female', None]
     phone: typing.List[str]
     weight: typing.Optional[float] = None
     birth_date: typing.Optional[datetime.date] = None
@@ -47,6 +54,7 @@ alice = Person(
     name='Alice',
     email='alice@example.com',
     alive=True,
+    gender='female',
     phone=['+31-6-1234-5678', '+31-20-123-4567'],
     weight=55.5,
     birth_date=datetime.date(1980, 4, 1),
@@ -58,6 +66,7 @@ bob = Person(
     name='Bob',
     email='bob@example.com',
     alive=False,
+    gender='male',
     phone=[],
 )
 
@@ -66,6 +75,7 @@ charlie = Person(
     name='Charlie',
     email='charlie@xample.com',
     alive=True,
+    gender='male',
     phone=[]
 )
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -26,7 +26,7 @@ class SerializerTestCase(TestCase):
 
         serializer = PersonSerializer()
         f = serializer.get_fields()
-        self.assertEqual(len(f), 9)
+        self.assertEqual(len(f), 10)
 
         self.assertIsInstance(f['id'], fields.UUIDField)
         self.assertFalse(f['id'].allow_null)
@@ -38,6 +38,13 @@ class SerializerTestCase(TestCase):
 
         self.assertIsInstance(f['alive'], fields.BooleanField)
         self.assertFalse(f['alive'].allow_null)
+
+        self.assertIsInstance(f['gender'], fields.ChoiceField)
+        self.assertTrue(f['gender'].allow_null)
+        self.assertFalse(f['gender'].allow_blank)
+        self.assertEqual(list(f['gender'].choices.keys()), ['male', 'female'])
+        self.assertTrue(f['gender'].allow_null)
+        self.assertFalse(f['gender'].allow_blank)
 
         self.assertIsInstance(f['weight'], fields.FloatField)
         self.assertTrue(f['weight'].allow_null)
@@ -111,6 +118,7 @@ class SerializationTestCase(TestCase):
         'name': person_instance.name,
         'email': person_instance.email,
         'alive': person_instance.alive,
+        'gender': person_instance.gender,
         'phone': person_instance.phone,
         'weight': person_instance.weight,
         'birth_date': person_instance.birth_date.isoformat(),
@@ -164,6 +172,7 @@ class NestedSerializationTestCase(TestCase):
             'name': house_dataclass.owner.name,
             'email': house_dataclass.owner.email,
             'alive': house_dataclass.owner.alive,
+            'gender': house_dataclass.owner.gender,
             'phone': house_dataclass.owner.phone,
             'weight': house_dataclass.owner.weight,
             'birth_date': house_dataclass.owner.birth_date.isoformat(),
@@ -175,6 +184,7 @@ class NestedSerializationTestCase(TestCase):
                 'name': house_dataclass.residents[0].name,
                 'email': house_dataclass.residents[0].email,
                 'alive': house_dataclass.residents[0].alive,
+                'gender': house_dataclass.residents[0].gender,
                 'phone': house_dataclass.residents[0].phone,
                 'weight': None,
                 'birth_date': None,

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -1,6 +1,6 @@
 import typing
 
-from unittest import TestCase
+from unittest import TestCase, SkipTest
 
 from rest_framework_dataclasses import typing_utils
 
@@ -61,3 +61,24 @@ class TypingTest(TestCase):
 
         with self.assertRaises(ValueError):
             typing_utils.get_optional_type(str)
+
+    # Make sure we recognize Literal from both 'typing' and 'typing_extensions'
+    def test_literal_py38(self):
+        try:
+            from typing import Literal
+        except ImportError:
+            raise SkipTest("typing.Literal not supported on current Python")
+
+        self.assertTrue(typing_utils.is_literal_type(Literal['a']))
+        self.assertEqual(typing_utils.get_literal_choices(Literal['a', 'b', None]),
+                         ('a', 'b', None))
+
+    def test_literal_extensions(self):
+        try:
+            from typing_extensions import Literal
+        except ImportError:
+            raise SkipTest("typing_extensions module not installed")
+
+        self.assertTrue(typing_utils.is_literal_type(Literal['a']))
+        self.assertEqual(typing_utils.get_literal_choices(Literal['a', 'b', None]),
+                         ('a', 'b', None))


### PR DESCRIPTION
Since the Literal type is not available before Python 3.8, this
introduces a new dependency typing_extensions, which backports it.