### PR TITLE
Better error message when encountering "special" types

### DIFF
--- a/rest_framework_dataclasses/field_utils.py
+++ b/rest_framework_dataclasses/field_utils.py
@@ -72,7 +72,13 @@ def get_relation_info(definition: DataclassDefinition, type_info: TypeInfo) -> R
 
 
 def lookup_type_in_mapping(mapping: typing.Dict[type, T], key: type) -> T:
-    for cls in inspect.getmro(key):
+    try:
+        # _SpecialForm types like Literal, NoReturn don't have an __mro__ attribute
+        bases = inspect.getmro(key)
+    except AttributeError:
+        raise KeyError("Special type {typ} not supported.".format(typ=key))
+
+    for cls in bases:
         if cls in mapping:
             return mapping[cls]
 


### PR DESCRIPTION
`_SpecialForm` types like `Literal`, `NoReturn` don't have an `__mro__` attribute.

Previously, using them in a dataclass caused `AttributeError`.

Also added a unit test for regular unsupported types.