### PR TITLE
Mark package as PEP 561 typing compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
         'Typing :: Typed'
     ],
     packages=find_packages(),
+    package_data={
+        'rest_framework_dataclasses': ['py.typed']
+    },
     python_requires='>=3.7',
     install_requires=[
         'django>=1.11',


### PR DESCRIPTION
This project is already mostly covered by type annotations. The
'py.typed' file is a signal to Mypy and other type checkers so they
don't complain about missing stubs.