### PR TITLE
Additional type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ MANIFEST
 # Testing
 .coverage
 .tox/
+.mypy_cache/
 
 # Environments
 .env

--- a/rest_framework_dataclasses/types.py
+++ b/rest_framework_dataclasses/types.py
@@ -1,6 +1,14 @@
-# Some type definitions that can be useful.
+"""Type aliases/definitions for type checkers"""
+from typing import TYPE_CHECKING, Type, Union, List, Tuple, Any, Dict
 
-from typing import Dict
+import rest_framework.fields
+
+
+# Define some types to make type hinting more readable
+KWArgs = Dict[str, Any]
+SerializerField = rest_framework.fields.Field
+SerializerFieldDefinition = Tuple[Type[SerializerField], KWArgs]
+FieldsType = Union[List[str], Tuple[str]]
 
 try:
     # Python 3.8 and later
@@ -12,3 +20,24 @@ except ImportError:
 # Note that this doesn't actually work yet (https://stackoverflow.com/a/55240861)
 class Dataclass(Protocol):
     __dataclass_fields__: Dict
+
+
+if TYPE_CHECKING:
+    FieldsOrAllType = Union[FieldsType, Literal['__all__']]
+
+    class _MetaProtocol(Protocol):
+        """
+        Type annotation for Serializer `Meta` attribute. `Protocol` indicates that it's a duck type, not parent class.
+        """
+        dataclass: type
+        fields: FieldsOrAllType
+        exclude: FieldsType
+        read_only_fields: FieldsType
+
+    Metaclass = Type[_MetaProtocol]
+
+else:
+    # FIXME: drop if?
+    # Fallback for Python 3.7, does not support Protocol, Literal
+    FieldsOrAllType = Union[FieldsType, str]
+    Metaclass = type


### PR DESCRIPTION
Maybe I went totally overboard with this :) but I've been searching for a project on which to try all-in mypy type checking support, and this sort of happened.

If you're interested, I can look into adding a mypy check run into Travis CI.

It's not quite there yet. The `serializers.py` file now wholly validates with mypy (along with djangorestframework-stubs), but not yet other files. `typing_utils.py` uses a fair bit of magic that (ironically) probably won't ever be understood by mypy, type checking should simply be suppressed there.
