### PR TITLE
Fix handling of nested Literal types

### DIFF
--- a/rest_framework_dataclasses/typing_utils.py
+++ b/rest_framework_dataclasses/typing_utils.py
@@ -130,8 +130,16 @@ def is_literal_type(tp: type) -> bool:
             or (isinstance(tp, typing._GenericAlias) and tp.__origin__ is Literal))
 
 
-def get_literal_choices(tp: type) -> tuple:
+def get_literal_choices(tp: type) -> typing.List[typing.Union[str, bytes, int, bool, None]]:
     """
     Return the possible values from a Literal[...] expression.
+    A Literal type may contain other Literals, so need to unnest those.
     """
-    return tp.__args__
+    # For more details: https://www.python.org/dev/peps/pep-0586/#legal-parameters-for-literal-at-type-check-time
+    values = []
+    for value in tp.__args__:
+        if is_literal_type(value):
+            values.extend(get_literal_choices(value))
+        else:
+            values.append(value)
+    return values

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -62,6 +62,15 @@ class TypingTest(TestCase):
         with self.assertRaises(ValueError):
             typing_utils.get_optional_type(str)
 
+    def test_literal_nested(self):
+        try:
+            from typing import Literal
+        except ImportError:
+            raise SkipTest("typing.Literal not supported on current Python")
+
+        self.assertEqual(typing_utils.get_literal_choices(Literal[Literal[Literal[1, 2, 3], "foo"], 5, None]),
+                         [1, 2, 3, "foo", 5, None])
+
     # Make sure we recognize Literal from both 'typing' and 'typing_extensions'
     def test_literal_py38(self):
         try:
@@ -71,7 +80,7 @@ class TypingTest(TestCase):
 
         self.assertTrue(typing_utils.is_literal_type(Literal['a']))
         self.assertEqual(typing_utils.get_literal_choices(Literal['a', 'b', None]),
-                         ('a', 'b', None))
+                         ['a', 'b', None])
 
     def test_literal_extensions(self):
         try:
@@ -81,4 +90,4 @@ class TypingTest(TestCase):
 
         self.assertTrue(typing_utils.is_literal_type(Literal['a']))
         self.assertEqual(typing_utils.get_literal_choices(Literal['a', 'b', None]),
-                         ('a', 'b', None))
+                         ['a', 'b', None])


### PR DESCRIPTION
Turns out there was a bug in #5. Whilst working on #8 it occurred to me that I left this case unhandled.

The set of allowed types in Literal[] is quite limited, but the case of
other nested Literal[]s was not properly handled.

For more details: https://www.python.org/dev/peps/pep-0586/#legal-parameters-for-literal-at-type-check-time