### PR TITLE
Support new X | Y union syntax in Python 3.10 (PEP 604)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+UNRELEASED
+----------
+Features & fixes:
+
+* Allow using the new ``X | None`` union syntax for specifying optional fields in Python 3.10+ (PEP 604).
+
 1.0.0, 23 October 2021
 ----------------------
 Features & fixes:

--- a/README.rst
+++ b/README.rst
@@ -116,8 +116,9 @@ The auto-generated serializer fields are configured based on type qualifiers in 
 * Fields with a default value (factory) are marked as optional on the serializer (``required=False``). This means that
   these fields don't need to be supplied during deserialization.
 
-* Fields marked as nullable through ``typing.Optional`` or ``typing.Union[X, None]`` are marked as nullable on the
-  serializer (``allow_null=True``). This means that ``None`` is accepted as a valid value during deserialization.
+* Fields marked as nullable through ``typing.Optional``, ``typing.Union[X, None]`` or ``X | None`` (`PEP 604`_) are
+  marked as nullable on the serializer (``allow_null=True``). This means that ``None`` is accepted as a valid value
+  during deserialization.
 
 * Fields marked as final through ``typing.Final`` (as in `PEP 591`_) are marked as read-only on the serializer
   (``read_only=True``).
@@ -443,4 +444,5 @@ Note that until version 1.0 these API's are not declared stable yet and might ch
 
 .. _`PEP 591`: https://www.python.org/dev/peps/pep-0591/
 .. _`PEP 585`: https://www.python.org/dev/peps/pep-0585/
+.. _`PEP 604`: https://www.python.org/dev/peps/pep-0604/
 .. _`property decorator`: https://docs.python.org/3/library/functions.html#property

--- a/rest_framework_dataclasses/typing_utils.py
+++ b/rest_framework_dataclasses/typing_utils.py
@@ -26,6 +26,13 @@ if hasattr(typing, '_BaseGenericAlias'):
 else:
     GenericAlias = typing._GenericAlias
 
+# types.UnionType was added in Python 3.10 for new PEP 604 pipe union syntax
+try:
+    from types import UnionType
+    UNION_TYPES = (typing.Union, UnionType)
+except ImportError:
+    UNION_TYPES = (typing.Union,)
+
 # Wrappers around typing.get_origin() and typing.get_args() for Python 3.7
 try:
     get_origin = typing.get_origin
@@ -131,7 +138,7 @@ def is_optional_type(tp: type) -> bool:
     none_type = type(None)
     return (
         origin is not None and
-        origin is typing.Union and
+        origin in UNION_TYPES and
         any(argument_type is none_type for argument_type in args) and
         any(argument_type is not none_type for argument_type in args)
     ) or (

--- a/tests/test_field_generation.py
+++ b/tests/test_field_generation.py
@@ -112,6 +112,11 @@ class FieldsTest(unittest.TestCase):
         self.assertDictEqual(dict_kwargs['child'].choices, {'a': 'a', 'b': 'b'})
         self.assertTrue(dict_kwargs['child'].allow_blank)
 
+    @unittest.skipIf(sys.version_info < (3, 10, 0), 'Python 3.10 required')
+    def test_composite_pep604(self):
+        self.check_field(typing.List[str] | None, fields.ListField)
+        self.check_field(typing.Dict[str, int] | None, fields.DictField)
+
     def test_nested(self):
         refclass = dataclasses.make_dataclass('ReferencedDataclass', [])
         self.check_field(refclass, DataclassSerializer,

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import datetime
+import sys
 import typing
 
 from unittest import TestCase

--- a/tests/test_typing_utils.py
+++ b/tests/test_typing_utils.py
@@ -79,6 +79,17 @@ class TypingTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             typing_utils.get_optional_type(str)
 
+    @unittest.skipIf(sys.version_info < (3, 10, 0), 'Python 3.10 required')
+    def test_optional_pep604(self):
+        # New PEP 604 union syntax in Python 3.10+
+        self.assertTrue(typing_utils.is_optional_type(str | None))
+        self.assertTrue(typing_utils.is_optional_type(None | str))
+
+        self.assertEqual(typing_utils.get_optional_type(str | None), str)
+        self.assertEqual(typing_utils.get_optional_type(None | str), str)
+
+        self.assertFalse(typing_utils.is_optional_type(int | str))
+
     def test_final(self):
         self.assertTrue(typing_utils.is_final_type(types.Final[int]))
         self.assertTrue(typing_utils.is_final_type(types.Final))


### PR DESCRIPTION
Allow using the new ``X | None`` union syntax for specifying optional fields in Python 3.10+ (PEP 604).