### PR TITLE
Support for `source="*"` embedded serializers from both drf and drfd

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -77,10 +77,6 @@ class SerializerTest(TestCase):
             definition = self.create_serializer(arguments={'dataclass': Person},
                                                 meta={}).dataclass_definition
 
-        # no `dataclass` parameter and missing `Meta`
-        with self.assertRaises(AssertionError):
-            definition = self.create_serializer().dataclass_definition
-
         # no `dataclass` parameter and invalid `Meta`
         with self.assertRaises(AssertionError):
             definition = self.create_serializer(meta={}).dataclass_definition


### PR DESCRIPTION
This solution allows for the use of both `rest_framework.serializers.Serializer` and `rest_framework_dataclasses.serializers.DataclassSerializer` to accept `source="*"` constructs.

It has the shortcoming that the requirement for `Meta.dataclass` needs to be defined, and will output a `dictionary` if this fails to be met, which doesn't look like a problem to me, but just in case for you to take it into account.