### PR TITLE
Support for `source="*"` embedded serializers from drf only

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -77,10 +77,6 @@ class SerializerTest(TestCase):
             definition = self.create_serializer(arguments={'dataclass': Person},
                                                 meta={}).dataclass_definition
 
-        # no `dataclass` parameter and missing `Meta`
-        with self.assertRaises(AssertionError):
-            definition = self.create_serializer().dataclass_definition
-
         # no `dataclass` parameter and invalid `Meta`
         with self.assertRaises(AssertionError):
             definition = self.create_serializer(meta={}).dataclass_definition


### PR DESCRIPTION
This solution allows for the use of `rest_framework.serializers.Serializer` only to accept `source="*"` constructs.

The only problem I see with this solution is that we are relying on the fact that DRF translates from dict to dict, and hence the fact that a dataclass needs to use an inner serializer of type DRF is somewhat an obscure pattern.

Solves #77 
Conflicts with #78 