### PR TITLE
Allow for union discriminators different from class names

### DIFF
--- a/rest_framework_dataclasses/fields.py
+++ b/rest_framework_dataclasses/fields.py
@@ -103,7 +103,7 @@ class UnionField(Field, Generic[T]):
             self.type_mapping[tp] = discriminator
 
     def get_discriminator(self, tp: type) -> str:
-        return tp.__name__
+        return getattr(tp, "serializer_discriminant", tp.__name__)
 
     def to_representation(self, data: T) -> Dict[str, Any]:
         discriminator = field_utils.lookup_type_in_mapping(self.type_mapping, type(data))

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -325,3 +325,45 @@ class SourceStarDefaultTest(TestCase, FunctionalTestMixin):
     serializer = PersonPetEmbeddedDefaultSerializer
     instance = PersonPet(name='Milo', pet=Pet(name='Katsu', animal='cat'))
     representation = {'name': 'Milo', 'pet': {'name': 'Katsu', 'animal': 'cat', 'owner_name': 'Milo'}}
+
+
+
+
+# Testcase 6 (union types with custom discriminator)
+
+
+@dataclasses.dataclass
+class Cycle:
+    diameter: float
+    type: Literal["cycle"] = "cycle"
+    serializer_discriminant = "cycle"
+
+
+@dataclasses.dataclass
+class Square:
+    side: float
+    type: Literal["square"] = "square"
+    serializer_discriminant = "square"
+
+
+@dataclasses.dataclass
+class Figure:
+    shape: typing.Union[Cycle, Square]
+
+
+class FigureSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = Figure
+
+
+class ShapeTest(TestCase, FunctionalTestMixin):
+    serializer = FigureSerializer
+    instance = Figure(
+        shape=Cycle(diameter=1.5)
+    )
+    representation = {
+        'shape': {
+            'type': 'cycle',
+            'diameter': 1.5,
+        }
+    }


### PR DESCRIPTION
I work with an application that uses lots of nested JSON structures which are modelled with dataclass unions on our end. 
Union discriminators are often part of the message payload and cannot be arbitrarily defined. Often they are short lowercase words which cannot be made to class names, since that would violate python conventions.

For example a dataclass could look like this. It is not possible to change the 'type' Literals, since they are part of an API specification.
``` python
@dataclasses.dataclass
class Wood:
    species: str
    type: Literal["wood"] = "wood"


@dataclasses.dataclass
class Steel:
    alloy: str
    type: Literal["steel"] = "steel"


@dataclasses.dataclass
class Building:
    material: typing.Union[Wood, Steel]
```
From what I see, to make those dataclasses work with serializers, I would have to subclass the UnionField, override `get_discriminator` and explicitly define this on my serializer:
This is already pretty verbose and it would get worse when there is further nesting, since I always have to explicitly redefine the nested structure as a serializer.

It would be nice to have a way on the dataclass to define its discriminator. I made an attempt here to add this by having a special attribute on the dataclass, but I am not sure if this is the best solution.