### PR TITLE
Fix type of `UnionField` to accept not only `Field` but also `Serializer`

### DIFF
--- a/rest_framework_dataclasses/fields.py
+++ b/rest_framework_dataclasses/fields.py
@@ -1,5 +1,5 @@
 import collections.abc
-from typing import Any, Dict, Generic, Type, TypeVar, Union, Optional
+from typing import Any, Dict, Generic, Mapping, Type, TypeVar, Union, Optional
 
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework.exceptions import ValidationError
@@ -80,7 +80,7 @@ class UnionField(Field, Generic[T]):
     type_mapping: Dict[type, str]
 
     def __init__(self,
-                 child_fields: Dict[type, Union[Field, Type[Field]]],
+                 child_fields: Mapping[type, Union[Field, Type[Field]]],
                  *,
                  nest_value: bool = False,
                  discriminator_field_name: Optional[str] = None,


### PR DESCRIPTION
Hello, thanks for your maintenance.

I fixed the constructor type of `UnionField` to accept not only `Field` but also subclass of `Field`, such as `Serializer`.

As described in [Common issues and solutions / variance in mypy document](https://mypy.readthedocs.io/en/stable/common_issues.html#variance), `Dict[T, U]` type does not accept subclass of `U`, while `Mapping` does. So I replace Dict with Mapping.

# Example
The code below causes error by mypy. After applying this PR, it does NOT causes any error.
```python
from dataclasses import dataclass

from rest_framework.fields import IntegerField

from rest_framework_dataclasses.fields import UnionField
from rest_framework_dataclasses.serializers import DataclassSerializer


@dataclass
class Example:
    x: int


class ExmapleSerializer(DataclassSerializer[Example]):
    class Meta:
        dataclass = Example


child_fields = {
    Example: ExmapleSerializer,
    int: IntegerField,
}

UnionField(child_fields=child_fields)
```

```
main.py:24: error: Argument "child_fields" to "UnionField" has incompatible type "dict[type, type]"; expected "dict[type, Field[Any, Any, Any, Any] | type[Field[Any, Any, Any, Any]]]"  [arg-type]
main.py:24: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
main.py:24: note: Consider using "Mapping" instead, which is covariant in the value type
Found 1 error in 1 file (checked 1 source file)
```