### PR TITLE
Add Django 5.2 and DRF 3.16 to CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
     py{38,39,310,311}-django{32}-drf{311,312,313,314,315}
     py{38,39,310,311}-django{40}-drf{313,314,315}
     py{38,39,310,311,312,313}-django{41}-drf{314,315}
-    py{38,39,310,311,312,313}-django{42}-drf{314,315,master}
-    py{310,311,312,313,314}-django{50,51}-drf{314,315,master}
+    py{39,310,311,312,313}-django{42}-drf{314,315,316,master}
+    py{310,311,312,313,314}-django{50,51,52}-drf{314,315,316,master}
 
 [gh-actions]
 python =
@@ -26,11 +26,13 @@ deps =
     django42: Django>=4.2,<5.0
     django50: Django>=5.0,<5.1
     django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
     drf311: djangorestframework>=3.11,<3.12
     drf312: djangorestframework>=3.12,<3.13
     drf313: djangorestframework>=3.13,<3.14
     drf314: djangorestframework>=3.14,<3.15
     drf315: djangorestframework>=3.15,<3.16
+    drf316: djangorestframework>=3.16,<3.17
     drfmaster: https://github.com/encode/django-rest-framework/archive/master.tar.gz
 commands =
     coverage run -a manage.py test


### PR DESCRIPTION
Also remove the combination of Python 3.8 with DRF 3.16 and master, as it isn't supported anymore and of little interest.